### PR TITLE
POST: Content-Length & Content-Type

### DIFF
--- a/src/ClientLifespan.cpp
+++ b/src/ClientLifespan.cpp
@@ -148,6 +148,16 @@ void	client_lifespan::CheckHeaderBeforeProcess(struct Client *clt)
 			}
 		}
 	}
+
+	//For POST with Content-Length (normal request, without chunks)
+	HeaderInt *content_length = static_cast<HeaderInt *>(clt->req.returnValueAsPointer("Content-Length"));
+	if ((clt->req.getMethod() == kPost) && !content_length && !clt->is_chunked)
+	{
+		clt->status_code = k411;
+		clt->consume_body = false;
+		return ;
+	}
+
 	return ;
 }
 


### PR DESCRIPTION
1. for POST without chunks and no Content-Length: response with 411
2. Avoid segfault when Header does not exist. Perhaps more strict tests needed.