### PR TITLE
Some fixes after submission

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -27,8 +27,8 @@ http {
 				image/png png;
 				application/pdf pdf;
     	}
-		client_max_body_size 4500;
-	  	cgi py /usr/bin/python3;
+      client_max_body_size 4500;
+      cgi py /usr/bin/python3;
     }
 
     location /upload {
@@ -36,10 +36,10 @@ http {
 	  	types {
         text/plain txt;
         text/html html;
-				image/jpeg jpg;
-				image/jpeg jpeg;
-				image/png png;
-				application/pdf pdf;
+        image/jpeg jpg;
+        image/jpeg jpeg;
+        image/png png;
+        application/pdf pdf;
       }
     }
 

--- a/src/Process.cpp
+++ b/src/Process.cpp
@@ -113,7 +113,7 @@ void	process::ProcessPostRequest(struct Client *clt)
 		req_content_type = "application/octet-stream";
 	else
 		req_content_type = content_type->content();
-	if ( !IsSupportedMediaType(req_content_type, location->mime_types)) // checkt content type from request with MIME type
+	if (!IsSupportedMediaType(req_content_type, location->mime_types)) // check content type from request with MIME type
 	{
 		clt->status_code = k415;
 		return (res_builder::GenerateErrorResponse(clt));
@@ -146,21 +146,21 @@ void	process::ProcessPostRequest(struct Client *clt)
 				clt->status_code = k403;
 				return (res_builder::GenerateErrorResponse(clt));
 			}
-			std::string existing_file_extension = GetReqExtension(clt->path);
-			if (!existing_file_extension.empty())
-			{
-				Maybe<directive::MimeTypes::MimeType> mime_type = location->mime_types->query(existing_file_extension);
-				if (!mime_type.is_ok())
-				{
-					clt->status_code = k415;
-					return (res_builder::GenerateErrorResponse(clt));
-				}
-				if (req_content_type != mime_type.value())
-				{
-					clt->status_code = k415;
-					return (res_builder::GenerateErrorResponse(clt));
-				}
-			}
+			// std::string existing_file_extension = GetReqExtension(clt->path);
+			// if (!existing_file_extension.empty())
+			// {
+			// 	Maybe<directive::MimeTypes::MimeType> mime_type = location->mime_types->query(existing_file_extension);
+			// 	if (!mime_type.is_ok())
+			// 	{
+			// 		clt->status_code = k415;
+			// 		return (res_builder::GenerateErrorResponse(clt));
+			// 	}
+			// 	if (req_content_type != mime_type.value())
+			// 	{
+			// 		clt->status_code = k415;
+			// 		return (res_builder::GenerateErrorResponse(clt));
+			// 	}
+			// }
 			if (file::ModifyFile(clt) == false)
 			{
 				clt->status_code = k500;

--- a/webserv_tests/webserv_tests.html
+++ b/webserv_tests/webserv_tests.html
@@ -28,7 +28,7 @@
 	<hr>
 	<h2>Test 04-1</h2>
 	<a href="http://localhost:8080/post/upload.html">File Upload</a>
-	<p>Do: Send POST Request for file upload (plain, txt, html, jpg, jpeg, png)</p>
+	<p>Do: Send POST Request for file upload (plain, txt, html, jpg, jpeg, png, pdf)</p>
 	<p>Expected: 201 Created, check if the file is in the /upload/</p>
 	<hr>
 	<h2>Test 04-2</h2>

--- a/www/display/list.py
+++ b/www/display/list.py
@@ -8,14 +8,14 @@ def index():
 	root = os.environ['DOCUMENT_ROOT']
 
 	upload_folder = root + '/upload'
-	files = os.listdir(upload_folder)
+	files = os.listdir(upload_folder) if os.path.exists(upload_folder) else []
 
 	# for generating uri
 	dir_path = '/upload'
 
 	# load script for list all the files
 	dir_cgi = os.path.dirname(__file__)
-	script_file = open( os.path.join(dir_cgi, 'del.js'), "r")
+	script_file = open(os.path.join(dir_cgi, 'del.js'), "r")
 	print(os.path.join(dir_cgi, 'del.js'), file=sys.stderr)
 
 	script = script_file.read()
@@ -29,10 +29,10 @@ def index():
 	html += "</body>\n"
 	html += "<script>" + script + "</script></html>"
 
-	# # TODO: For testing generated html, can be deleted aftertesting
-	f = open( os.path.join(dir_cgi, 'delete.html'), "w+")
-	f.write(html)
-	f.close()
+	# # TODO: For testing generated html, can be deleted after testing
+	# f = open(os.path.join(dir_cgi, 'delete.html'), "w+")
+	# f.write(html)
+	# f.close()
 	# # End of TODO
 
 	print("Content-Type: text/html", end='\r\n')


### PR DESCRIPTION
fix: /display works when the directory non-exists instead of sending 500 server error
fix: deleted redundant mime type checking (mime type is once checked in the previous code, and human readable files such as .c and .hpp are sorted as text/plain, so reverse checking does not make sense)